### PR TITLE
Fixed error /bin/sh: 1: /usr/local/bin/pip3.7: not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN addgroup prometheus
 RUN adduser --disabled-password --no-create-home --home /app  --gecos '' --ingroup prometheus prometheus
 
 COPY requirements.txt /app/
-RUN /usr/local/bin/pip3.7 install -r /app/requirements.txt
+RUN /usr/local/bin/pip install -r /app/requirements.txt
 
 COPY tibber-exporter.py /app/
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6859862/185452361-28871dec-0816-4b93-8700-e33773e05498.png)

The current version gives an error when building. A simple fix is to remove the version suffix from pip.
