### PR TITLE
Fixed Tibber API breaking changes (Dec 2022)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 asyncio
 requests==2.28.1
-python-graphql-client>=0.4.1
+# Temporary fix:
+# revert to once merged: python-graphql-client>=0.4.1
+git+https://github.com/jenskdsgn/python-graphql-client@master#python-graphql-client
 prometheus_client

--- a/tibber-exporter.py
+++ b/tibber-exporter.py
@@ -19,7 +19,7 @@ from prometheus_client import start_http_server, Gauge
 from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily, REGISTRY
 
 PORT = 9110
-SUBSCRIPTION_ENDPOINT = 'wss://api.tibber.com/v1-beta/gql/subscriptions'
+SUBSCRIPTION_ENDPOINT = 'wss://websocket-api.tibber.com/v1-beta/gql/subscriptions'
 QUERY_ENDPOINT = 'https://api.tibber.com/v1-beta/gql'
 RT_HOMES = {}
 
@@ -80,7 +80,8 @@ class TibberHomeRT(object):
         """.format(homeid=self.id)
         self.subscription_task = asyncio.create_task(self.subscription_client.subscribe(query=query,
             handle=self.handle_live_measurement,
-            init_payload={'token': self.token}))
+            init_payload={'token': self.token},
+            ws_subprotocol='graphql-transport-ws'))
         self.subscription_start = datetime.now()
         self.connect_count += 1
 


### PR DESCRIPTION
The PR aims to quick fix the breaking changes introduced by the tibber API

https://developer.tibber.com/docs/overview#breaking-websocket-change

> This API initially supported GraphQL websocket subscriptions using [graphql-ws](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md) sub-protocol. However, that library is [archived and no longer maintained](https://github.com/apollographql/subscriptions-transport-ws). Thus, on March 31, 2022, support for [graphql-transport-ws](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) sub-protocol was added.

After brief research the it felt like exactly the opposite, that [graphql-transport-ws](https://www.npmjs.com/package/graphql-transport-ws) would be the deprecated one.
The graphql library that was picked only supports graphql-ws, so I hope they accept my [PR](https://github.com/prodigyeducation/python-graphql-client/pull/53) to add the other subprotocol as well. For the time being, I pointed my the reference to my repository with the fix in the graphql library. Once their PR is merged we can point it to the official one again. I guess this is better as to have a fully broken exporter.


This was the error message I encountered:

```
Starting subscription for homeId e9b4af2f-a55c-49ab-af78-da422855c551
Suspending thread waiting for task Gather
Subscription connection error (server rejected WebSocket connection: HTTP 404)
Voiding subscription for e9b4af2f-a55c-49ab-af78-da422855c551
```

I compared the websocket messages with Tibbers GraphQL playground and found the mismatching ws subprotocols.

Also they have changed the GraphQL Subscription URL. It would be better to get them dynamically from the GraphQL query API. My Python skills didn't allow to also do that quickly so I just updated the URL.
